### PR TITLE
Update setup.py for markdown-based readme

### DIFF
--- a/illumidesk_theia_proxy/__init__.py
+++ b/illumidesk_theia_proxy/__init__.py
@@ -7,6 +7,7 @@ for more information.
 import os
 import shutil
 
+
 def setup_theia():
     # Make sure theia is in $PATH
     def _theia_command(port):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
 import setuptools
+from os import path
+
+# read the contents of your README file
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setuptools.setup(
     name="illumidesk-theia-proxy",
@@ -6,6 +12,8 @@ setuptools.setup(
     url="https://github.com/illumidesk/illumidesk-theia-proxy",
     author="IllumiDesk Team",
     description="hello@illumidesk.com",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=setuptools.find_packages(),
 	keywords=['jupyter', 'theia', 'jupyterhub'],
 	classifiers=['Framework :: Jupyter'],


### PR DESCRIPTION
Removes `long_description_content_type` and `long_description` warnings.