### PR TITLE
Add icon full name and extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setuptools.setup(
         ]
     },
     package_data={
-        'illumidesk-theia-proxy': ['icons/*'],
+        'illumidesk-theia-proxy': ['icons/theia.svg'],
     },
 )


### PR DESCRIPTION
Updates the package's setup to copy icon to JupyterLab's launcher.