### PR TITLE
Add support to launch from binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [Theia](https://www.theia-ide.org/) is a configurable web-based IDE
 that supports [Visual Studio Code](https://code.visualstudio.com/) compatible extensions. This package was built using the [`jupyter-server-proxy` cookiecutter template](https://github.com/jupyterhub/jupyter-server-proxy/tree/master/contrib/template).
 
+Try in binder:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/illumidesk/illumidesk-theia-proxy/main?urlpath=theia)
+
 ## Installation
 
 ```bash

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,3 @@
+jupyter serverextension enable --sys-prefix jupyter_server_proxy
+jupyter labextension install @jupyterlab/server-proxy
+jupyter lab build

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
 	keywords=['jupyter', 'theia', 'jupyterhub'],
 	classifiers=['Framework :: Jupyter'],
     install_requires=[
-        'jupyter-server-proxy'
+        'jupyter-server-proxy>=1.5.0'
     ],
     entry_points={
         'jupyter_serverproxy_servers': [


### PR DESCRIPTION
- Adds `binder` badge to Readme
- Includes `postBuild` to enable and install `jupyter-server-proxy` extensions